### PR TITLE
Fix GitHub Pages deployment configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:gh-pages": "vite build --base=/lab_clock/",
+    "build:gh-pages": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: '/clock/',
 })


### PR DESCRIPTION
## Summary
- vite.config.tsのベースパスを`/clock/`に設定（リポジトリ名に合わせて）
- package.jsonのbuild:gh-pagesスクリプトから重複する--baseオプションを削除
- これによりGitHub Pagesが正しいパスでアプリケーションを提供できるようになります

## Test plan
- [ ] GitHub Actionsでビルドが成功することを確認
- [ ] GitHub Pagesにデプロイ後、https://akin0ri.github.io/clock/ でアプリケーションが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)